### PR TITLE
Bug fix

### DIFF
--- a/src/Virulence_Factors/virulencefactors.py
+++ b/src/Virulence_Factors/virulencefactors.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import os, sys, logging, argparse, subprocess, shutil
+import os, sys, logging, argparse, subprocess, shutil, json
 
 TEMP_SCRIPT_DIRECTORY = os.path.dirname(os.path.abspath(__file__)) + "/"
 sys.path.append(os.path.abspath(TEMP_SCRIPT_DIRECTORY + '../Serotyper/'))
@@ -164,7 +164,7 @@ if __name__=='__main__':
             if args.csv == 1:
                 toTSV(resultsDict, 'VF_Results')
 
-            print resultsDict
+            json.dump(resultsDict, sys.stdout)
             logging.info('Program ended successfully.')
 
     else:

--- a/src/Virulence_Factors/virulencefactors.py
+++ b/src/Virulence_Factors/virulencefactors.py
@@ -9,7 +9,7 @@ sys.path.append(os.path.abspath(TEMP_SCRIPT_DIRECTORY + '../'))
 from sharedmethods import *
 from ecvalidatingfiles import *
 
-SCRIPT_DIRECTORY = os.path.dirname(os.path.abspath(__file__)) + "/"
+SCRIPT_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
 GENOMES = {}
 FILENAMES = {}
 
@@ -93,7 +93,11 @@ def searchDB(genomesList):
         new_filename = os.path.abspath(os.path.join(REL_DIR, filename + '.xml'))
 
     #Querying the database
-    blastn_cline = NcbiblastnCommandline(cmd="blastn", query=combined_genomes, db= REL_DIR + '../databases/VF_Database/VirulenceFactorsDB', outfmt=5, out= new_filename)
+
+    db_path = os.path.join(REL_DIR, '../databases/VF_Database/VirulenceFactorsDB')
+
+    blastn_cline = NcbiblastnCommandline(cmd="blastn", query=combined_genomes,
+                                         db=db_path, outfmt=5, out=new_filename)
     stdout, stderr = blastn_cline()
 
     logging.info("Searched the database.")

--- a/src/Virulence_Factors/virulencefactors.py
+++ b/src/Virulence_Factors/virulencefactors.py
@@ -84,13 +84,13 @@ def searchDB(genomesList):
                 with open(file, 'rb') as fastafile:
                     shutil.copyfileobj(fastafile, outfile,1024*1024*10)
 
-        new_filename = os.path.abspath(REL_DIR  + 'combined_genomesVF.xml')
+        new_filename = os.path.abspath(os.path.join(REL_DIR, 'combined_genomesVF.xml'))
 
     else:
         filename = os.path.basename(genomesList[0])
-        filename = os.path.splitext(filename)
+        filename, ext = os.path.splitext(filename)
         combined_genomes = genomesList[0]
-        new_filename = os.path.abspath(REL_DIR + str(filename[0]) + '.xml')
+        new_filename = os.path.abspath(os.path.join(REL_DIR, filename + '.xml'))
 
     #Querying the database
     blastn_cline = NcbiblastnCommandline(cmd="blastn", query=combined_genomes, db= REL_DIR + '../databases/VF_Database/VirulenceFactorsDB', outfmt=5, out= new_filename)
@@ -153,7 +153,8 @@ def parseFile(result_file, perc_len, perc_id):
 
 if __name__=='__main__':
 
-    logging.basicConfig(filename=SCRIPT_DIRECTORY + 'virulencefactors.log',level=logging.INFO)
+    log_path = os.path.join(SCRIPT_DIRECTORY, 'virulencefactors.log')
+    logging.basicConfig(filename=log_path,level=logging.INFO)
 
     args = parseCommandLine()
     createDirs()


### PR DESCRIPTION
- Fixes JSON output
    - Was previously `print`ing a Python `dict`, which is similar, but _quite_ the same as JSON

- Readability improvements
    - Uses `__future__` / Python3 float division
    - Add whitespace
    - Reorganize some code

- Use `os.path.join` instead of `"some/path" + "/" + filename + ".xml"`

- Invokes `makeblastdb` so that it searches `$PATH`, instead of directly calling `/usr/bin/makeblastdb`
    - Avoids crash in cases where `makeblastdb` is located somewhere other than `/usr/bin/`, such as  `usr/local/bin`, or if it was installed manually or with `brew`