### PR TITLE
amr is working

### DIFF
--- a/src/RGI/rgitool.py
+++ b/src/RGI/rgitool.py
@@ -72,18 +72,18 @@ def getResults(genomesList, RGIpath):
 
         #Generating the results from the RGI tool
         out = rel_dir + genome_name
-        temp_result = subprocess.call(['python', RGIpath + 'rgi.py', "-i", genome_file, "-o", out])
+        temp_result = subprocess.call(['rgi.py', "-i", genome_file, "-o", out])
 
         #Obtaining a readable JSON file of the results
         formatted_out = rel_dir + genome_name + '_FORMATTED'
-        temp_result = subprocess.call(['python',  RGIpath + 'formatJson.py', "-i", SCRIPT_DIRECTORY + '../../' + out + '.json', "-o", formatted_out])
+        temp_result = subprocess.call(['rgi_jsonformat', "-i", SCRIPT_DIRECTORY + '../../' + out + '.json', "-o", formatted_out])
 
         with open(SCRIPT_DIRECTORY + '../../' + formatted_out + '.json', 'r') as temp_file:
             GENOMES[genome_name] = json.load(temp_file)
 
         #Generating a CSV file of the results
         csv_out = rel_dir + genome_name
-        temp_result = subprocess.call(['python',  RGIpath + 'convertJsonToTSV.py', "-i", SCRIPT_DIRECTORY + '../../' + formatted_out + '.json', "-o", csv_out])
+        temp_result = subprocess.call(['rgi_jsontab', "-i", SCRIPT_DIRECTORY + '../../' + formatted_out + '.json', "-o", csv_out])
 
         os.rename(SCRIPT_DIRECTORY + '../../' + csv_out + '.txt', SCRIPT_DIRECTORY + '../../' + csv_out + '.tsv')
         os.remove(SCRIPT_DIRECTORY + '../../' + formatted_out + '.json')

--- a/src/RGI/rgitool.py
+++ b/src/RGI/rgitool.py
@@ -72,7 +72,7 @@ def getResults(genomesList, RGIpath):
 
         #Generating the results from the RGI tool
         out = rel_dir + genome_name
-        temp_result = subprocess.call(['rgi.py', "-i", genome_file, "-o", out])
+        temp_result = subprocess.call(['rgi', "-i", genome_file, "-o", out])
 
         #Obtaining a readable JSON file of the results
         formatted_out = rel_dir + genome_name + '_FORMATTED'


### PR DESCRIPTION
I've changed the subprocess calls in rgitool.py to reference the modules themselves (w/o the .py). Intending to offload all dependency resolution in the future to conda instead of installing components of rgi (& other stuff) separately; see: https://github.com/kevinkle/superphy_conda/blob/master/environment.yml

The ECtyper tool may still need to be run from its directory due to path handling when creating temporary files. 

Example of output: https://gist.github.com/kevinkle/5b1e95adf238240cdadb36422b8cd010

This change may not work if components were installed separately (w/o conda).